### PR TITLE
Exemplo sem utilização de reflect

### DIFF
--- a/example-no-reflect/cpf.go
+++ b/example-no-reflect/cpf.go
@@ -1,0 +1,40 @@
+package main
+
+import validation "github.com/go-ozzo/ozzo-validation"
+
+func init() {
+	doc := &CPF{}
+	DocumentTypes[doc.Type()] = func() Document {
+		return &CPF{}
+	}
+}
+
+type CPF struct {
+	Numero       string
+	Comprovantes []Voucher
+}
+
+func (d CPF) Context() string {
+	return ContextBrazil
+}
+
+func (d CPF) Type() string {
+	return "cpf"
+}
+
+func (d CPF) Vouchers() []Voucher {
+	return d.Comprovantes
+}
+
+func (d CPF) Validate() error {
+	return validation.ValidateStruct(&d,
+		validation.Field(&d.Numero, validation.Length(11, 0)),
+		validation.Field(
+			&d.Comprovantes,
+			validation.Length(1, 2),
+			validation.By(AllowedVouches{
+				"frente",
+			}.CheckIfAllowed),
+		),
+	)
+}

--- a/example-no-reflect/document.go
+++ b/example-no-reflect/document.go
@@ -1,0 +1,21 @@
+package main
+
+const ContextBrazil string = "brazil"
+
+var DocumentTypes = map[string]func() Document{}
+
+type Document interface {
+	Context() string
+	Type() string
+	Vouchers() []Voucher
+	Validate() error
+}
+
+func NewDocument(key string) (Document, bool) {
+	data, exists := DocumentTypes[key]
+
+	if !exists {
+		return nil, false
+	}
+	return data(), true
+}

--- a/example-no-reflect/main.go
+++ b/example-no-reflect/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func createRG() RG {
+	return RG{
+		Numero:             "376817884",
+		OrgaoEmissor:       "SSP",
+		UF:                 "SP",
+		DataExpedicao:      time.Now().AddDate(-1, 0, 0),
+		NaturalidadeEstado: "SP",
+		NaturalidadeCidade: "São Paulo",
+		Filiacao1:          "Margie Simpson",
+		Filiacao2:          "Homer Simpson",
+		Comprovantes: []Voucher{
+			{
+				Type: "frente",
+				File: "/img/teste.jpg",
+			},
+			{
+				Type: "verso",
+				File: "/img/teste.jpg",
+			},
+		},
+	}
+}
+
+func createCPF() CPF {
+	return CPF{
+		Numero: "25036156005",
+		Comprovantes: []Voucher{
+			{
+				Type: "frente",
+				File: "/img/teste.jpg",
+			},
+		},
+	}
+}
+
+func main() {
+	rg := createDocumentSpec(createRG())
+	cpf := createDocumentSpec(createCPF())
+
+	store := MemoryStore{}
+
+	err := store.Save(rg)
+	if err != nil {
+		panic(err)
+	}
+
+	err = store.Save(cpf)
+	if err != nil {
+		panic(err)
+	}
+
+	docs, err := store.List()
+	if err != nil {
+		panic(err)
+	}
+
+	spew.Dump(docs)
+}

--- a/example-no-reflect/memstore.go
+++ b/example-no-reflect/memstore.go
@@ -1,0 +1,39 @@
+package main
+
+import "encoding/json"
+
+type MemoryStore struct {
+	documents [][]byte
+}
+
+func (s *MemoryStore) Save(spec DocumentSpec) error {
+	err := spec.Data.Validate()
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(spec)
+	if err != nil {
+		return err
+	}
+
+	s.documents = append(s.documents, b)
+	return nil
+}
+
+func (s MemoryStore) List() ([]DocumentSpec, error) {
+	docs := make([]DocumentSpec, 0)
+
+	for _, b := range s.documents {
+		var doc DocumentSpec
+
+		err := json.Unmarshal(b, &doc)
+		if err != nil {
+			return nil, err
+		}
+
+		docs = append(docs, doc)
+	}
+
+	return docs, nil
+}

--- a/example-no-reflect/rg.go
+++ b/example-no-reflect/rg.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+func init() {
+	doc := &RG{}
+	DocumentTypes[doc.Type()] = func() Document {
+		return &RG{}
+	}
+}
+
+type RG struct {
+	Numero             string
+	OrgaoEmissor       string
+	UF                 string
+	DataExpedicao      time.Time
+	NaturalidadeEstado string
+	NaturalidadeCidade string
+	Filiacao1          string
+	Filiacao2          string
+	Comprovantes       []Voucher
+}
+
+func (d RG) Context() string {
+	return ContextBrazil
+}
+
+func (d RG) Type() string {
+	return "rg"
+}
+
+func (d RG) Vouchers() []Voucher {
+	return d.Comprovantes
+}
+
+func (d RG) Validate() error {
+	now, _ := time.Parse("2006-01-02", time.Now().Format("2006-01-02"))
+
+	return validation.ValidateStruct(&d,
+		validation.Field(&d.Numero, validation.Length(1, 255)),
+		validation.Field(&d.OrgaoEmissor, validation.In(OrgaoEmissor...)),
+		validation.Field(&d.UF, validation.In(UF...)),
+		validation.Field(&d.DataExpedicao, validation.Max(now)),
+		validation.Field(&d.NaturalidadeEstado, validation.In(UF...)),
+		validation.Field(&d.Filiacao1, validation.Length(1, 255)),
+		validation.Field(&d.Filiacao2, validation.Length(1, 255)),
+		validation.Field(
+			&d.Comprovantes,
+			validation.Length(1, 2),
+			validation.By(AllowedVouches{
+				"frente",
+				"verso",
+			}.CheckIfAllowed),
+		),
+	)
+}
+
+var OrgaoEmissor = []interface{}{
+	"SSP",
+	"SSPDC",
+	"SESP",
+}
+
+var UF = []interface{}{
+	"MG",
+	"RJ",
+	"SP",
+}

--- a/example-no-reflect/spec.go
+++ b/example-no-reflect/spec.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type DocumentSpec struct {
+	Context string
+	Type    string
+	Data    Document
+}
+
+func (s *DocumentSpec) UnmarshalJSON(b []byte) error {
+	type Alias DocumentSpec
+
+	tmp := struct {
+		Alias
+		Data json.RawMessage
+	}{}
+
+	err := json.Unmarshal(b, &tmp)
+	if err != nil {
+		return err
+	}
+
+	*s = DocumentSpec(tmp.Alias)
+
+	data, exists := NewDocument(s.Type)
+	if !exists {
+		return errors.New("invalid document type")
+	}
+
+	err = json.Unmarshal(tmp.Data, &data)
+	if err != nil {
+		return err
+	}
+
+	s.Data = data
+
+	return nil
+}
+
+func createDocumentSpec(doc Document) DocumentSpec {
+	return DocumentSpec{
+		Context: doc.Context(),
+		Type:    doc.Type(),
+		Data:    doc,
+	}
+}

--- a/example-no-reflect/voucher.go
+++ b/example-no-reflect/voucher.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+type Voucher struct {
+	Type string
+	File string
+}
+
+type AllowedVouches []string
+
+func (a AllowedVouches) CheckIfAllowed(val interface{}) error {
+	switch reflect.TypeOf(val).Kind() {
+	case reflect.Struct:
+		if reflect.TypeOf(Voucher{}) != reflect.TypeOf(val) {
+			panic(fmt.Errorf(`parameter is "%T" but should be "%T""`, reflect.TypeOf(val), reflect.TypeOf(Voucher{})))
+		}
+
+		errs := make(validation.Errors, 0)
+
+		vouch := reflect.ValueOf(val).Interface().(Voucher)
+
+		if !a.CheckInArray(vouch.Type) {
+			errs["type"] = fmt.Errorf(`document does not require file "%s"`, vouch.Type)
+		}
+
+		err := validation.Validate(&vouch)
+		if err != nil {
+			valError := err.(validation.Errors)
+			for k, v := range valError {
+				errs[k] = v
+			}
+		}
+
+		if len(errs) > 0 {
+			return errs
+		}
+
+		return nil
+
+	case reflect.Slice, reflect.Array:
+		if reflect.TypeOf([]Voucher{}) != reflect.TypeOf(val) {
+			panic(fmt.Errorf(`parameter is "%T" but should be "%T""`, reflect.TypeOf(val), reflect.TypeOf([]Voucher{})))
+		}
+
+		err := make(validation.Errors, 0)
+
+		slice := reflect.ValueOf(val).Interface().([]Voucher)
+
+		for index, file := range slice {
+			er := a.CheckIfAllowed(file)
+			if er != nil {
+				i := strconv.Itoa(index)
+
+				err[i] = er
+			}
+		}
+
+		if len(err) > 0 {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a AllowedVouches) CheckInArray(t string) bool {
+	for _, allow := range a {
+		if t == allow {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Rafael,

Apenas modificando a assinatura do seu mapa de documentos é possível não utilizar reflect.

```
var DocumentTypes = map[string]func() Document{}
...
func NewDocument(key string) (Document, bool) {
	data, exists := DocumentTypes[key]
	if !exists {
		return nil, false
	}
	return data(), true
}
```

rg.go
```
func init() {
	doc := &RG{}
	DocumentTypes[doc.Type()] = func() Document {
		return &RG{}
	}
}
```

cpf.go
```
func init() {
	doc := &CPF{}
	DocumentTypes[doc.Type()] = func() Document {
		return &CPF{}
	}
}
```